### PR TITLE
check that player is set before using it

### DIFF
--- a/src/java/net/p455w0rd/wirelesscraftingterminal/common/utils/RandomUtils.java
+++ b/src/java/net/p455w0rd/wirelesscraftingterminal/common/utils/RandomUtils.java
@@ -40,7 +40,7 @@ public class RandomUtils {
 	}
 
 	public static ItemStack getWirelessTerm(InventoryPlayer playerInv) {
-		if (playerInv.player.getHeldItem() != null && playerInv.player.getHeldItem().getItem() instanceof IWirelessCraftingTerminalItem) {
+		if (playerInv.player != null && playerInv.player.getHeldItem() != null && playerInv.player.getHeldItem().getItem() instanceof IWirelessCraftingTerminalItem) {
 			return playerInv.player.getHeldItem();
 		}
 		ItemStack wirelessTerm = null;
@@ -63,7 +63,7 @@ public class RandomUtils {
 
 	public static ItemStack getMagnet(InventoryPlayer playerInv) {
 		// Is player holding a Magnet Card?
-		if (playerInv.player.getHeldItem() != null && playerInv.player.getHeldItem().getItem() instanceof ItemMagnet) {
+		if (playerInv.player != null && playerInv.player.getHeldItem() != null && playerInv.player.getHeldItem().getItem() instanceof ItemMagnet) {
 			return playerInv.player.getHeldItem();
 		}
 		// if not true, try to return first magnet card from first


### PR DESCRIPTION
this check is not necessary with EntityPlayerMP but from FakePlayer it
is possible that the field has not been set. In OpenComputesr, our robot
had not set this field (we are now) but I thought it would be nice to
have this fix on both sides. This NRE was causing our robot to fail to
pickup items through a pickup event listener coming back to this code.

We could have instead added an instanceOf check on the player (as null
is not an instance of anything in java), but, I thought it would be
nice for FakePlayers to be able to mimic when possible.